### PR TITLE
Basic windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,6 @@ issue where the `echo` program stopped working. It worked on
 
 git bisect told me the commit `183ef5e2f0ba6124efac98efba67757f1e8b2aa9` broke it.
 That doesn't seem to be relevant at all so not sure what happened.
+
+Make sure the tag used for the binary ninja rust dependency matches the version of
+binary ninja that is being used. Otherwise really weird errors will occur.

--- a/emulator/Cargo.toml
+++ b/emulator/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 # binaryninja = { git = "https://github.com/james-a-johnson/binaryninja-api.git", branch = "const-mask" }
-binaryninja = { git = "https://github.com/Vector35/binaryninja-api.git", rev = "0317c1a5c51e623a00249ecdefa0c5dd582e0eb1" }
+binaryninja = { git = "https://github.com/Vector35/binaryninja-api.git", tag = "dev/5.3.8813" }
 softmew = { path = "../softmew" }
 from_id = { path = "../from_id" }
 val = { path = "../val" }


### PR DESCRIPTION
Arm64 linux emulation relied on a unix
specific trait. This changes the linux
emulation to only use that on unix
systems and handle paths differently
on Windows.